### PR TITLE
Errata corrige geometry slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ DD4hep description of a dual-readout endcap calorimeter using the capillary tube
 ![DREndcapTube](https://github.com/user-attachments/assets/f1acdfd0-afd3-4279-b557-055692a43477)
 
 ## Presentations
-- FCC Full Simulation Meeting, 24/7/2024, [DD4hep implementation of the IDEA Endcap Calo with the capillary tubes technology](https://indico.cern.ch/event/1439207/contributions/6056623/attachments/2903299/5092292/lopezzot_fccsim_2472024.pdf)
+- FCC Full Simulation Meeting, 24/7/2024, [DD4hep implementation of the IDEA Endcap Calo with the capillary tubes technology](https://indico.cern.ch/event/1439207/contributions/6056623/attachments/2903299/5092292/lopezzot_fccsim_2472024.pdf) (errata corrige: slide 5 "~1.1 Gb" -> "~2.1 Gb")
 
 ## How to
 ### Build and compile using the key4hep stack


### PR DESCRIPTION
Add errata corrige for slides on geometry. I rebuilt the geometry on Mac and it takes ~2.1 Gb, likely it was a typo.