### PR TITLE
Add September 24 presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ DD4hep description of a dual-readout endcap calorimeter using the capillary tube
 ![DREndcapTube](https://github.com/user-attachments/assets/f1acdfd0-afd3-4279-b557-055692a43477)
 
 ## Presentations
+- FCC Full Simulation Meeting, 18/9/2024, [SW performance of the IDEA Dual-Readout tubes-based calorimeter simulation](https://indico.cern.ch/event/1457476/contributions/6136107/attachments/2929865/5144647/lopezzot_fccsim_1892024.pdf)
 - FCC Full Simulation Meeting, 24/7/2024, [DD4hep implementation of the IDEA Endcap Calo with the capillary tubes technology](https://indico.cern.ch/event/1439207/contributions/6056623/attachments/2903299/5092292/lopezzot_fccsim_2472024.pdf) (errata corrige: slide 5 "~1.1 Gb" -> "~2.1 Gb")
 
 ## How to


### PR DESCRIPTION
Add a link to the September 2024 FCC Full Sim Meeting presentation.