### PR TITLE
Kill Cher photons traveling towards fiber tip

### DIFF
--- a/DRdetector/DRsensitive/src/DREndcapTubesSDAction.cpp
+++ b/DRdetector/DRsensitive/src/DREndcapTubesSDAction.cpp
@@ -235,6 +235,8 @@ bool Geant4SensitiveAction<DREndcapTubesSDData>::process(const G4Step* aStep,
 
       switch (theStatus) {
         case TotalInternalReflection: {
+          // Kill Cherenkov photons inside fibers travelling towards the inner tip
+          if (!DREndcapTubesSglHpr::IsReflectedForward(aStep)) return true;
           G4double distance_to_sipm = DREndcapTubesSglHpr::GetDistanceToSiPM(aStep);
           G4int c_signal = DREndcapTubesSglHpr::SmearCSignal();
           signalhit = DREndcapTubesSglHpr::AttenuateCSignal(c_signal, distance_to_sipm);


### PR DESCRIPTION
If a Cherenkov photon trapped inside a fiber is traveling toward the inner fiber tip (instead of the SiPM readout tip) this should be killed. Added a method to check if the photon is traveling forward or backward and adjusted the Cherenkov light smearing parameter increasing it to 16% as killing those photons reduces the Cherenkov light yield by 16%.