### PR TITLE
Save inner tip position in output file

### DIFF
--- a/DRdetector/DRsensitive/include/DREndcapTubesSglHpr.hh
+++ b/DRdetector/DRsensitive/include/DREndcapTubesSglHpr.hh
@@ -64,7 +64,7 @@ class DREndcapTubesSglHpr
       return AttenuateHelper(signal, distance, fCAttenuationLength);
     }
 
-    inline static G4ThreeVector CalculateSiPMPosition(const G4Step* step);
+    inline static G4ThreeVector CalculateFiberPosition(const G4Step* step);
 
     // Check if photon is travelling towards SiPM
     inline static bool IsReflectedForward(const G4Step* step);
@@ -104,7 +104,7 @@ inline G4int DREndcapTubesSglHpr::AttenuateHelper(const G4int& signal, const G4d
   return survived_photons;
 }
 
-inline G4ThreeVector DREndcapTubesSglHpr::CalculateSiPMPosition(const G4Step* step)
+inline G4ThreeVector DREndcapTubesSglHpr::CalculateFiberPosition(const G4Step* step)
 {
   G4TouchableHandle theTouchable = step->GetPreStepPoint()->GetTouchableHandle();
   G4ThreeVector origin(0., 0., 0.);
@@ -124,11 +124,11 @@ inline G4ThreeVector DREndcapTubesSglHpr::CalculateSiPMPosition(const G4Step* st
   G4double lengthfiber = size * 2.;
   G4ThreeVector Halffibervect = direction * lengthfiber / 2;
   // Fibre tip position
-  // G4ThreeVector vectPostip = vectPos-Halffibervect;
+  G4ThreeVector vectPostip = vectPos - Halffibervect;
   // SiPM position
-  G4ThreeVector SiPMvecPos = vectPos + Halffibervect;
+  // G4ThreeVector SiPMvecPos = vectPos + Halffibervect;
 
-  return SiPMvecPos;
+  return vectPostip;
 }
 
 // Check if photon is travelling towards SiPM

--- a/DRdetector/DRsensitive/src/DREndcapTubesSDAction.cpp
+++ b/DRdetector/DRsensitive/src/DREndcapTubesSDAction.cpp
@@ -263,9 +263,9 @@ bool Geant4SensitiveAction<DREndcapTubesSDData>::process(const G4Step* aStep,
   if (!hit) {  // if the hit does not exist yet, create it
     hit = new Geant4Calorimeter::Hit();
     hit->cellID = VolID;  // this should be assigned only once
-    G4ThreeVector SiPMVec = DREndcapTubesSglHpr::CalculateSiPMPosition(aStep);
-    Position SiPMPos(SiPMVec.x(), SiPMVec.y(), SiPMVec.z());
-    hit->position = SiPMPos;  // this should be assigned only once
+    G4ThreeVector FiberVec = DREndcapTubesSglHpr::CalculateFiberPosition(aStep);
+    Position FiberPos(FiberVec.x(), FiberVec.y(), FiberVec.z());
+    hit->position = FiberPos;  // this should be assigned only once
     // Note, when the hit is saved in edm4hep format the energyDeposit is
     // divided by 1000, i.e. it translates from MeV (Geant4 unit) to GeV (DD4hep unit).
     // Here I am using this field to save photo-electrons, so I multiply it by 1000


### PR DESCRIPTION
The hit position is assigned as the fiber inner tip instead of the SiPM position.