### PR TITLE
Recreate VolID in SDAction using CpNumbers

### DIFF
--- a/DRdetector/DRcalo/compact/DREndcapTubes.xml
+++ b/DRdetector/DRcalo/compact/DREndcapTubes.xml
@@ -316,7 +316,7 @@
              grid_size_x="1*mm" 
              grid_size_y="1*mm"/>
       <!-- NO SPACES BETWEEN ID DESCRIPTORS!!! -->
-      <id>tank:1,endcap:1,stave:10,tower:8,air:1,col:10,row:7,clad:1,core:1,cherenkov:1</id>
+      <id>stave:10,tower:6,air:1,col:16,row:16,clad:1,core:1,cherenkov:1</id>
     </readout>
   </readouts> 
 


### PR DESCRIPTION
The readout bit structure has been somplified removing tank and endcap entries. In the geometry construction the copynumbers have been set identical to the volIDs, or split into bits to allocated multiple volIDs for the volume.
In the SDAction the copynumbers are split into bits and used to recreated the volID with the BitFieldCoder. This slows down the simulation by about 20%. This slowdown should be investigated.